### PR TITLE
Add top offset support

### DIFF
--- a/lib/ParallaxView.js
+++ b/lib/ParallaxView.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var React = require('react');
 var ReactNative = require('react-native');
 var {
@@ -17,22 +19,22 @@ var ScrollableMixin = require('react-native-scrollable-mixin');
 var screen = Dimensions.get('window');
 var ScrollViewPropTypes = ScrollView.propTypes;
 
-var ParallaxView = React.createClass({
+var ParallaxView = createReactClass({
     mixins: [ScrollableMixin],
 
     propTypes: {
         ...ScrollViewPropTypes,
-        windowHeight: React.PropTypes.number,
-        backgroundSource: React.PropTypes.oneOfType([
-          React.PropTypes.shape({
-            uri: React.PropTypes.string,
+        windowHeight: PropTypes.number,
+        backgroundSource: PropTypes.oneOfType([
+          PropTypes.shape({
+            uri: PropTypes.string,
           }),
           // Opaque type returned by require('./image.jpg')
-          React.PropTypes.number,
+          PropTypes.number,
         ]),
-        header: React.PropTypes.node,
-        blur: React.PropTypes.string,
-        contentInset: React.PropTypes.object,
+        header: PropTypes.node,
+        blur: PropTypes.string,
+        contentInset: PropTypes.object,
     },
 
     getDefaultProps: function () {
@@ -63,7 +65,7 @@ var ParallaxView = React.createClass({
     },
 
     renderBackground: function () {
-        var { windowHeight, backgroundSource, blur } = this.props;
+        var { windowHeight, backgroundSource, blur, topOffset } = this.props;
         var { scrollY } = this.state;
         if (!windowHeight || !backgroundSource) {
             return null;
@@ -82,7 +84,8 @@ var ParallaxView = React.createClass({
                             inputRange: [ -windowHeight, 0, windowHeight],
                             outputRange: [2, 1, 1]
                         })
-                    }]
+                    }],
+                    top: topOffset
                 }]}
                 source={backgroundSource}>
                 {/*
@@ -114,14 +117,14 @@ var ParallaxView = React.createClass({
     },
 
     render: function () {
-        var { style, ...props } = this.props;
+        var { style, topOffset, ...props } = this.props;
         return (
             <View style={[styles.container, style]}>
                 {this.renderBackground()}
                 <ScrollView
                     ref={component => { this._scrollView = component; }}
                     {...props}
-                    style={styles.scrollView}
+                    style={[styles.scrollView, { paddingTop: topOffset }]}
                     onScroll={Animated.event(
                       [{ nativeEvent: { contentOffset: { y: this.state.scrollY }}}]
                     )}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "create-react-class": "^15.6.2",
     "prop-types": "^15.6.0",
-    "react": "^16.6.3",
+    "react": "^16.0.0",
     "react-native-scrollable-mixin": "^1.0.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   },
   "homepage": "https://github.com/lelandrichardson/react-native-parallax-view",
   "dependencies": {
+    "create-react-class": "^15.6.2",
+    "prop-types": "^15.6.0",
+    "react": "^16.6.3",
     "react-native-scrollable-mixin": "^1.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
We need to support an initial scroll offset at the top of the view.
This is useful for iOS top header translucency where the parallax view
will occupy space behind the header but needs to start with the
content visible. Then as the user scrolls, the content can be seen
sliding, behind the header.